### PR TITLE
New Segment Handling, some tweaks (on correct branch)

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -14,8 +14,8 @@
       <file leaf-file-name="Speedrun.lua" pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/Speedrun.lua">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="170">
-              <caret line="10" column="0" lean-forward="false" selection-start-line="10" selection-start-column="0" selection-end-line="12" selection-end-column="17" />
+            <state relative-caret-position="-2385">
+              <caret line="15" column="8" lean-forward="false" selection-start-line="15" selection-start-column="8" selection-end-line="15" selection-end-column="8" />
               <folding />
             </state>
           </provider>
@@ -24,8 +24,8 @@
       <file leaf-file-name="SpeedrunUI.lua" pinned="false" current-in-tab="true">
         <entry file="file://$PROJECT_DIR$/SpeedrunUI.lua">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="-158">
-              <caret line="68" column="38" lean-forward="true" selection-start-line="68" selection-start-column="38" selection-end-line="68" selection-end-column="38" />
+            <state relative-caret-position="272">
+              <caret line="122" column="0" lean-forward="true" selection-start-line="122" selection-start-column="0" selection-end-line="122" selection-end-column="0" />
               <folding />
             </state>
           </provider>
@@ -34,8 +34,8 @@
       <file leaf-file-name="SpeedrunUI.xml" pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/SpeedrunUI.xml">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="799">
-              <caret line="47" column="108" lean-forward="false" selection-start-line="47" selection-start-column="108" selection-end-line="47" selection-end-column="108" />
+            <state relative-caret-position="686">
+              <caret line="73" column="57" lean-forward="false" selection-start-line="73" selection-start-column="38" selection-end-line="73" selection-end-column="57" />
               <folding />
             </state>
           </provider>
@@ -64,8 +64,8 @@
       <file leaf-file-name="main.lua" pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/../HodorReflexes/modules/share/main.lua">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="11407">
-              <caret line="671" column="17" lean-forward="false" selection-start-line="671" selection-start-column="17" selection-end-line="671" selection-end-column="17" />
+            <state relative-caret-position="182">
+              <caret line="633" column="21" lean-forward="true" selection-start-line="633" selection-start-column="21" selection-end-line="633" selection-end-column="21" />
               <folding />
             </state>
           </provider>
@@ -94,8 +94,15 @@
       <file leaf-file-name="SpeedrunData.lua" pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/SpeedrunData.lua">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="3842">
-              <caret line="226" column="0" lean-forward="true" selection-start-line="226" selection-start-column="0" selection-end-line="226" selection-end-column="0" />
+            <state relative-caret-position="828">
+              <caret line="219" column="21" lean-forward="false" selection-start-line="219" selection-start-column="21" selection-end-line="219" selection-end-column="21" />
+              <caret line="218" column="21" lean-forward="false" selection-start-line="218" selection-start-column="21" selection-end-line="218" selection-end-column="21" />
+              <caret line="220" column="21" lean-forward="false" selection-start-line="220" selection-start-column="21" selection-end-line="220" selection-end-column="21" />
+              <caret line="221" column="21" lean-forward="false" selection-start-line="221" selection-start-column="21" selection-end-line="221" selection-end-column="21" />
+              <caret line="222" column="21" lean-forward="false" selection-start-line="222" selection-start-column="21" selection-end-line="222" selection-end-column="21" />
+              <caret line="223" column="21" lean-forward="false" selection-start-line="223" selection-start-column="21" selection-end-line="223" selection-end-column="21" />
+              <caret line="224" column="21" lean-forward="false" selection-start-line="224" selection-start-column="21" selection-end-line="224" selection-end-column="21" />
+              <caret line="225" column="21" lean-forward="false" selection-start-line="225" selection-start-column="21" selection-end-line="225" selection-end-column="21" />
               <folding />
             </state>
           </provider>
@@ -104,7 +111,7 @@
       <file leaf-file-name="DebuffMe.lua" pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/../DebuffMe/DebuffMe.lua">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="828">
+            <state relative-caret-position="7565">
               <caret line="445" column="14" lean-forward="false" selection-start-line="0" selection-start-column="0" selection-end-line="498" selection-end-column="90" />
               <folding />
             </state>
@@ -115,7 +122,6 @@
   </component>
   <component name="FindInProjectRecents">
     <findStrings>
-      <find>SetAnchor</find>
       <find>getn</find>
       <find>M</find>
       <find>RestorePosition</find>
@@ -145,6 +151,7 @@
       <find>Saved</find>
       <find>ToggleMovable</find>
       <find>SpeedRun_TotalTimer</find>
+      <find>diff</find>
     </findStrings>
     <replaceStrings>
       <replace>stepList[636]</replace>
@@ -173,8 +180,8 @@
         <option value="$PROJECT_DIR$/../AsylumTracker/AsylumTracker.xml" />
         <option value="$PROJECT_DIR$/../DebuffMe/DebuffMe.lua" />
         <option value="$PROJECT_DIR$/SpeedrunUI.xml" />
-        <option value="$PROJECT_DIR$/SpeedrunData.lua" />
         <option value="$PROJECT_DIR$/Speedrun.lua" />
+        <option value="$PROJECT_DIR$/SpeedrunData.lua" />
         <option value="$PROJECT_DIR$/SpeedrunUI.lua" />
       </list>
     </option>
@@ -187,7 +194,7 @@
   </component>
   <component name="PhpWorkspaceProjectConfiguration" backward_compatibility_performed="true" />
   <component name="ProjectFrameBounds" extendedState="6">
-    <option name="x" value="1736" />
+    <option name="x" value="2342" />
     <option name="y" value="-42" />
     <option name="width" value="1449" />
     <option name="height" value="1056" />
@@ -207,8 +214,10 @@
       <foldersAlwaysOnTop value="true" />
     </navigator>
     <panes>
-      <pane id="Scope" />
+      <pane id="PackagesPane" />
+      <pane id="AndroidView" />
       <pane id="Scratches" />
+      <pane id="Scope" />
       <pane id="ProjectPane">
         <subPane>
           <expand>
@@ -231,8 +240,6 @@
           <select />
         </subPane>
       </pane>
-      <pane id="AndroidView" />
-      <pane id="PackagesPane" />
     </panes>
   </component>
   <component name="PropertiesComponent">
@@ -354,12 +361,14 @@
       <updated>1557071603693</updated>
       <workItem from="1557071606756" duration="25515000" />
       <workItem from="1557136114016" duration="41664000" />
-      <workItem from="1557257133336" duration="1024000" />
+      <workItem from="1557257133336" duration="1858000" />
+      <workItem from="1557349883381" duration="47000" />
+      <workItem from="1557437613473" duration="7419000" />
     </task>
     <servers />
   </component>
   <component name="TimeTrackingManager">
-    <option name="totallyTimeSpent" value="68203000" />
+    <option name="totallyTimeSpent" value="76503000" />
   </component>
   <component name="ToolWindowManager">
     <frame x="1912" y="-42" width="2576" height="1056" extended-state="6" />
@@ -387,7 +396,7 @@
       <window_info id="Version Control" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="7" side_tool="false" content_ui="tabs" />
       <window_info id="Run" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="2" side_tool="false" content_ui="tabs" />
       <window_info id="Terminal" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="7" side_tool="false" content_ui="tabs" />
-      <window_info id="Project" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="true" show_stripe_button="true" weight="0.105325915" sideWeight="0.5" order="0" side_tool="false" content_ui="combo" />
+      <window_info id="Project" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="true" show_stripe_button="true" weight="0.10731319" sideWeight="0.5" order="0" side_tool="false" content_ui="combo" />
       <window_info id="Remote Spark Job in Cluster" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="7" side_tool="false" content_ui="tabs" />
       <window_info id="Debug Remote Spark Job in Cluster" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="7" side_tool="false" content_ui="tabs" />
       <window_info id="Theme Preview" active="false" anchor="right" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="3" side_tool="false" content_ui="tabs" />
@@ -411,6 +420,14 @@
     <watches-manager />
   </component>
   <component name="editorHistoryManager">
+    <entry file="file://$PROJECT_DIR$/../DebuffMe/DebuffMe.lua">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="7565">
+          <caret line="445" column="14" lean-forward="false" selection-start-line="0" selection-start-column="0" selection-end-line="498" selection-end-column="90" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
     <entry file="file://$PROJECT_DIR$/Speedrun.lua">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="3995">
@@ -684,14 +701,6 @@
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/../HodorReflexes/modules/share/main.lua">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="11407">
-          <caret line="671" column="17" lean-forward="false" selection-start-line="671" selection-start-column="17" selection-end-line="671" selection-end-column="17" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
     <entry file="file://$PROJECT_DIR$/../Raidificator/lib/core.lua">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="1598">
@@ -729,34 +738,26 @@
         </state>
       </provider>
     </entry>
+    <entry file="file://$PROJECT_DIR$/../DebuffMe/DebuffMe.lua">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="7565">
+          <caret line="445" column="14" lean-forward="false" selection-start-line="0" selection-start-column="0" selection-end-line="498" selection-end-column="90" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/../HodorReflexes/modules/share/main.lua">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="182">
+          <caret line="633" column="21" lean-forward="true" selection-start-line="633" selection-start-column="21" selection-end-line="633" selection-end-column="21" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
     <entry file="file://$PROJECT_DIR$/../AsylumTracker/AsylumTracker.xml">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="187">
           <caret line="11" column="44" lean-forward="false" selection-start-line="11" selection-start-column="44" selection-end-line="11" selection-end-column="44" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/SpeedrunUI.xml">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="799">
-          <caret line="47" column="108" lean-forward="false" selection-start-line="47" selection-start-column="108" selection-end-line="47" selection-end-column="108" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/SpeedrunData.lua">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="3842">
-          <caret line="226" column="0" lean-forward="true" selection-start-line="226" selection-start-column="0" selection-end-line="226" selection-end-column="0" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/../DebuffMe/DebuffMe.lua">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="828">
-          <caret line="445" column="14" lean-forward="false" selection-start-line="0" selection-start-column="0" selection-end-line="498" selection-end-column="90" />
           <folding />
         </state>
       </provider>
@@ -769,18 +770,41 @@
         </state>
       </provider>
     </entry>
+    <entry file="file://$PROJECT_DIR$/SpeedrunUI.xml">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="686">
+          <caret line="73" column="57" lean-forward="false" selection-start-line="73" selection-start-column="38" selection-end-line="73" selection-end-column="57" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/SpeedrunData.lua">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="828">
+          <caret line="219" column="21" lean-forward="false" selection-start-line="219" selection-start-column="21" selection-end-line="219" selection-end-column="21" />
+          <caret line="218" column="21" lean-forward="false" selection-start-line="218" selection-start-column="21" selection-end-line="218" selection-end-column="21" />
+          <caret line="220" column="21" lean-forward="false" selection-start-line="220" selection-start-column="21" selection-end-line="220" selection-end-column="21" />
+          <caret line="221" column="21" lean-forward="false" selection-start-line="221" selection-start-column="21" selection-end-line="221" selection-end-column="21" />
+          <caret line="222" column="21" lean-forward="false" selection-start-line="222" selection-start-column="21" selection-end-line="222" selection-end-column="21" />
+          <caret line="223" column="21" lean-forward="false" selection-start-line="223" selection-start-column="21" selection-end-line="223" selection-end-column="21" />
+          <caret line="224" column="21" lean-forward="false" selection-start-line="224" selection-start-column="21" selection-end-line="224" selection-end-column="21" />
+          <caret line="225" column="21" lean-forward="false" selection-start-line="225" selection-start-column="21" selection-end-line="225" selection-end-column="21" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
     <entry file="file://$PROJECT_DIR$/Speedrun.lua">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="170">
-          <caret line="10" column="0" lean-forward="false" selection-start-line="10" selection-start-column="0" selection-end-line="12" selection-end-column="17" />
+        <state relative-caret-position="-2385">
+          <caret line="15" column="8" lean-forward="false" selection-start-line="15" selection-start-column="8" selection-end-line="15" selection-end-column="8" />
           <folding />
         </state>
       </provider>
     </entry>
     <entry file="file://$PROJECT_DIR$/SpeedrunUI.lua">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="-158">
-          <caret line="68" column="38" lean-forward="true" selection-start-line="68" selection-start-column="38" selection-end-line="68" selection-end-column="38" />
+        <state relative-caret-position="272">
+          <caret line="122" column="0" lean-forward="true" selection-start-line="122" selection-start-column="0" selection-end-line="122" selection-end-column="0" />
           <folding />
         </state>
       </provider>

--- a/Speedrun.lua
+++ b/Speedrun.lua
@@ -13,6 +13,7 @@ Speedrun.raidID = 0
 Speedrun.Step = 0
 Speedrun.currentRaidTimer = {}
 Speedrun.isBossDead = true
+Speedrun.segmentTimer = {}
 
 ---------------------------
 ---- Variables Default ----
@@ -27,7 +28,8 @@ Speedrun.Default = {
 	lastBossName = "",
 	raidID = 0,
 	isBossDead = true,
-	Step = 0
+	Step = 0,
+	segmentTimer = {}
 }
 Speedrun.Default.customTimerSteps = Speedrun.customTimerSteps
 Speedrun.Default.raidList = Speedrun.raidList
@@ -143,7 +145,7 @@ function Speedrun.MainCloudrest()
 				Speedrun.UpdateWaypoint()
 
 				Speedrun.lastBossName = GetUnitName("boss" .. i)
-				Speedrun.savedVariables.lastBossName = Speedrun.lastBossName 
+				Speedrun.savedVariables.lastBossName = Speedrun.lastBossName
 			end
 			if IsUnitInCombat("player") then    
 				local percentageHP = currentTargetHP / maxTargetHP 

--- a/SpeedrunData.lua
+++ b/SpeedrunData.lua
@@ -216,20 +216,20 @@ Speedrun.stepList = {
 }
 
 --TEST
--- Speedrun.raidList[639].timerSteps[1] = 1000
--- Speedrun.raidList[639].timerSteps[2] = 1200000
--- Speedrun.raidList[639].timerSteps[3] = 2200000
--- Speedrun.raidList[639].timerSteps[4] = 2400000
--- Speedrun.raidList[639].timerSteps[5] = 3000000
--- Speedrun.raidList[639].timerSteps[6] = 3600000
--- Speedrun.raidList[639].timerSteps[7] = 4600000
--- Speedrun.raidList[639].timerSteps[8] = 5600000
+Speedrun.raidList[639].timerSteps[1] = 720000
+Speedrun.raidList[639].timerSteps[2] = 90000
+Speedrun.raidList[639].timerSteps[3] = 120000
+Speedrun.raidList[639].timerSteps[4] = 90000
+Speedrun.raidList[639].timerSteps[5] = 120000
+Speedrun.raidList[639].timerSteps[6] = 90000
+Speedrun.raidList[639].timerSteps[7] = 120000
+Speedrun.raidList[639].timerSteps[8] = 90000
 
---Speedrun.raidList[638].timerSteps[1] = 1800000
---Speedrun.raidList[638].timerSteps[2] = 1900000
---Speedrun.raidList[638].timerSteps[3] = 2200000
---Speedrun.raidList[638].timerSteps[4] = 2400000
---Speedrun.raidList[638].timerSteps[5] = 3000000
---Speedrun.raidList[638].timerSteps[6] = 3600000
---Speedrun.raidList[638].timerSteps[7] = 4600000
---Speedrun.raidList[638].timerSteps[8] = 5600000
+Speedrun.raidList[638].timerSteps[1] = 720000
+Speedrun.raidList[638].timerSteps[2] = 90000
+Speedrun.raidList[638].timerSteps[3] = 120000
+Speedrun.raidList[638].timerSteps[4] = 90000
+Speedrun.raidList[638].timerSteps[5] = 120000
+Speedrun.raidList[638].timerSteps[6] = 90000
+Speedrun.raidList[638].timerSteps[7] = 120000
+Speedrun.raidList[638].timerSteps[8] = 90000

--- a/SpeedrunUI.lua
+++ b/SpeedrunUI.lua
@@ -81,10 +81,18 @@ function Speedrun.CreateRaidSegment(id)
         segmentRow:GetNamedChild('_Name'):SetText(x);
 
         if raid.timerSteps[i] then
-            segmentRow:GetNamedChild('_Best'):SetText(Speedrun.FormatRaidTimer(raid.timerSteps[i], true))
+
+            if i == 1 then
+                Speedrun.segmentTimer[i] = raid.timerSteps[i]
+            else
+                Speedrun.segmentTimer[i] = raid.timerSteps[i] + Speedrun.segmentTimer[i-1]
+            end
+
+            segmentRow:GetNamedChild('_Best'):SetText(Speedrun.FormatRaidTimer(Speedrun.segmentTimer[i], true))
         else
             segmentRow:GetNamedChild('_Best'):SetText("NA:NA")
         end
+
 
     --TODO NIQUE TAGRAND LUI DE CON
         if i == 1 then
@@ -104,23 +112,39 @@ end
 
 function Speedrun.UpdateSegment(step, raid)
 
-    --TODO if raid already has steptimer
-    --d("UpdateSegment")
+    --TODO Divide into multiple function
+
     local difference
-    if raid.timerSteps[step] then
-        difference = GetRaidDuration() - raid.timerSteps[step]
+    if Speedrun.segmentTimer[step] then
+        difference = GetRaidDuration() - Speedrun.segmentTimer[step]
     else
         difference = 0
     end
-    Speedrun.segments[Speedrun.Step]:GetNamedChild('_Best'):SetText(Speedrun.FormatRaidTimer(GetRaidDuration()))
 
+    local previousSegementDif
+    if raid.timerSteps[step] then
+        previousSegementDif = (GetRaidDuration() - Speedrun.segmentTimer[step-1]) - raid.timerSteps[step]
+    else
+        previousSegementDif = 0
+    end
+
+
+    local bestPossibleTime =  difference + Speedrun.segmentTimer[table.getn(Speedrun.segmentTimer)]
+    SpeedRun_Advanced_BestPossible_Value:SetText(Speedrun.FormatRaidTimer(bestPossibleTime))
+    SpeedRun_Advanced_PreviousSegment:SetText(Speedrun.FormatRaidTimer(previousSegementDif))
+    Speedrun.segments[Speedrun.Step]:GetNamedChild('_Best'):SetText(Speedrun.FormatRaidTimer(GetRaidDuration()))
 
     local segment = Speedrun.segments[Speedrun.Step]:GetNamedChild('_Diff')
     segment:SetText(Speedrun.FormatRaidTimer(difference, true))
-    if difference > 0 then
+
+    Speedrun.DifferenceColor(difference, segment)
+    Speedrun.DifferenceColor(previousSegementDif, SpeedRun_Advanced_PreviousSegment)
+end
+
+function Speedrun.DifferenceColor(diff, segment)
+    if diff > 0 then
         segment:SetColor(unpack{1,0,0})
     else
         segment:SetColor(unpack{0,1,0})
     end
 end
-

--- a/SpeedrunUI.xml
+++ b/SpeedrunUI.xml
@@ -60,7 +60,7 @@
                     <Anchor point="TOPLEFT" relativePoint="BOTTOMLEFT" relativeTo="$(parent)" offsetX="0" offsetY="0" />
                 </Label>
 
-                <Label name="$(parent)_Best" horizontalAlignment="right" verticalAlignment="center" font="ZoFontWinH5" text="21:02">
+                <Label name="$(parent)_PreviousSegment" horizontalAlignment="right" verticalAlignment="center" font="ZoFontWinH5" text="21:02">
                     <Dimensions x="125" y="20"/>
                     <Anchor point="LEFT" relativePoint="RIGHT" relativeTo="$(parent)_Label" offsetX="0" offsetY="0" />
                 </Label>


### PR DESCRIPTION
###  DONE 
- Previous Segment calculated and displayed on each waypoint
- Best time calculated based on remaining waypoint + time won or lost on the current run
- Time won / lost on the raid calculated and displayed
- Fixing UpdateWaypointNew (nil value + number = error)

### TODOS 
- fixing nil values here and there
- adding the "no segment data" handling for the new version
- Time before nextstep before you start loosing time
- Reset UI when raid is failed or entering another raid